### PR TITLE
Hotfixed clear button not working  on first note entry

### DIFF
--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -109,8 +109,12 @@ const handleNoteView = (e) => {
 };
 
 // Sets the activeNote to and empty object and allows the user to enter a new note
+// [trnigg] - renderActiveNote button handles the clearing of the input fields and is a call back on the clearBtn event listener;
+// [cont.] however, it doesn't seem to be resetting .value on the first item.
 const handleNewNoteView = (e) => {
   activeNote = {};
+  noteTitle.value = '';
+  noteText.value = '';
   show(clearBtn);
   renderActiveNote();
 };


### PR DESCRIPTION
- Seems to have fixed the input fields not being cleared when no other note exists.
- See #14 